### PR TITLE
Minecraft 26 compatibility

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -12,8 +12,12 @@ repositories {
 }
 
 dependencies {
+    implementation(libs.kotlinReflect)
+    implementation(libs.kotlinStdlib)
+    implementation(libs.kotlinStdlib7)
+    implementation(libs.kotlinStdlib8)
     implementation(libs.kotlin)
-    implementation(libs.licenser)
+//    implementation(libs.licenser)
     implementation(libs.blossom)
     implementation(libs.shadow)
     implementation(libs.loom)

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -1,6 +1,13 @@
 import ca.stellardrift.build.configurate.ConfigFormats
 import ca.stellardrift.build.configurate.catalog.PolyglotVersionCatalogExtension
 
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
 plugins {
     id("ca.stellardrift.polyglot-version-catalogs") version "6.1.0"
 }

--- a/build-logic/src/main/kotlin/extensions/Git.kt
+++ b/build-logic/src/main/kotlin/extensions/Git.kt
@@ -6,12 +6,11 @@ import java.io.ByteArrayOutputStream
 fun Project.getLatestGitCommitHash(): String {
     return try {
         val byteOut = ByteArrayOutputStream()
-        project.exec {
-            this.commandLine = "git rev-parse --short HEAD".split(" ")
-            this.standardOutput = byteOut
+        val task = providers.exec {
+            commandLine("git rev-parse --short HEAD".split(" "))
         }
 
-        byteOut.toString("UTF-8").trim()
+        task.standardOutput.asText.get()
     } catch (ex: Exception) {
         "Unknown"
     }
@@ -20,15 +19,11 @@ fun Project.getLatestGitCommitHash(): String {
 fun Project.getPreviousTag(): String {
     return try
     {
-        val byteOut = ByteArrayOutputStream()
-        val error = ByteArrayOutputStream()
-        project.exec {
-            this.commandLine = "git describe --abbrev=0 --tags --exclude=${getLatestTag()}".split(" ")
-            this.standardOutput = byteOut
-            this.errorOutput = error
+        val task = providers.exec {
+            commandLine("git describe --abbrev=0 --tags --exclude=${getLatestTag()}".split(" "))
         }
 
-        byteOut.toString("UTF-8").trim()
+        task.standardOutput.asText.get()
     } catch (ex: Exception) {
         "Unknown"
     }
@@ -38,12 +33,11 @@ fun Project.getLatestTag(): String {
     return try
     {
         val byteOut = ByteArrayOutputStream()
-        project.exec {
-            this.commandLine = "git describe --abbrev=0 --tags".split(" ")
-            this.standardOutput = byteOut
+        val task = providers.exec {
+            commandLine("git describe --abbrev=0 --tags".split(" "))
         }
 
-        byteOut.toString("UTF-8").trim()
+        task.standardOutput.asText.get()
     } catch (ex: Exception) {
         "Unknown"
     }

--- a/build-logic/src/main/kotlin/impactor.base-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/impactor.base-conventions.gradle.kts
@@ -2,7 +2,7 @@ import extensions.getLatestGitCommitHash
 
 plugins {
     `java-library`
-    id("org.cadixdev.licenser")
+//    id("org.cadixdev.licenser")
     id("net.kyori.blossom")
     kotlin("jvm")
 }
@@ -25,6 +25,7 @@ repositories {
             includeModule("me.lucko", "spark-api")
         }
     }
+    maven("https://jitpack.io")
 
 }
 
@@ -32,27 +33,28 @@ version = rootProject.version
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(25))
     }
 }
 
 tasks {
     withType<JavaCompile> {
         options.encoding = "UTF-8"
-        dependsOn(updateLicenses)
+//        dependsOn(updateLicenses)
         finalizedBy(test)
     }
 
     jar {
         if(project.parent?.name.equals("api")) {
-            archiveBaseName.set("Impactor-API-${project.name.substring(0, 1).toUpperCase()}${project.name.substring(1)}")
+            archiveBaseName.set("Impactor-API-${project.name.substring(0, 1).uppercase()}${project.name.substring(1)}")
         } else {
-            archiveBaseName.set("Impactor-${project.name.substring(0, 1).toUpperCase()}${project.name.substring(1)}")
+            archiveBaseName.set("Impactor-${project.name.substring(0, 1).uppercase()}${project.name.substring(1)}")
         }
         archiveClassifier.set("dev-slim")
     }
 }
 
+/*
 license {
     header(rootProject.file("HEADER.txt"))
     properties {
@@ -61,6 +63,7 @@ license {
         this.set("year", 2022)
     }
 }
+*/
 
 sourceSets {
     main {

--- a/build-logic/src/main/kotlin/impactor.base-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/impactor.base-conventions.gradle.kts
@@ -26,7 +26,7 @@ repositories {
         }
     }
     maven("https://jitpack.io")
-
+    mavenLocal()
 }
 
 version = rootProject.version

--- a/build-logic/src/main/kotlin/impactor.launcher-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/impactor.launcher-conventions.gradle.kts
@@ -30,6 +30,36 @@ dependencies {
     ).forEach { include(it) }
 }
 
+dependencies {
+    include(project(":api:core"))
+    include(project(":api:config"))
+    include(project(":api:economy"))
+    include(project(":api:items"))
+    include(project(":api:mail"))
+    include(project(":api:players"))
+    include(project(":api:plugins"))
+    include(project(":api:scoreboard"))
+    include(project(":api:storage"))
+    include(project(":api:text"))
+    include(project(":api:translations"))
+    include(project(":api:ui"))
+    include(project(":impactor"))
+    include(project(":minecraft:api"))
+    include(project(":minecraft:impl"))
+
+
+    //from :impactor - api
+    include("net.impactdev.impactor.api:commands:5.3.1+26.1.2")
+
+    include("com.zaxxer:HikariCP:5.0.1")
+    include("com.h2database:h2:2.1.214")
+    include("mysql:mysql-connector-java:8.0.33")
+    include("org.mariadb.jdbc:mariadb-java-client:3.1.2")
+    include("org.mongodb:mongo-java-driver:3.12.12")
+
+    include("com.github.ben-manes.caffeine:caffeine:3.1.5")
+}
+
 tasks {
     shadowJar {
         archiveBaseName.set("Impactor-${project.name}")

--- a/build-logic/src/main/kotlin/impactor.launcher-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/impactor.launcher-conventions.gradle.kts
@@ -1,7 +1,5 @@
 import extensions.isRelease
 import extensions.writeVersion
-import net.fabricmc.loom.task.RemapJarTask
-import org.gradle.configurationcache.extensions.capitalized
 
 plugins {
     id("impactor.loom-conventions")
@@ -19,34 +17,20 @@ dependencies {
     listOf(
         "net.kyori:examination-api:1.3.0",
         "net.kyori:examination-string:1.3.0",
-        "net.kyori:adventure-api:4.17.0",
-        "net.kyori:adventure-key:4.17.0",
-        "net.kyori:adventure-nbt:4.17.0",
-        "net.kyori:adventure-text-serializer-plain:4.17.0",
-        "net.kyori:adventure-text-serializer-legacy:4.17.0",
-        "net.kyori:adventure-text-serializer-gson:4.17.0",
-        "net.kyori:adventure-text-serializer-json:4.17.0",
-        "net.kyori:adventure-text-minimessage:4.17.0",
-        "net.kyori:adventure-text-logger-slf4j:4.17.0",
-        "net.kyori:event-api:5.0.0-SNAPSHOT",
+        "net.kyori:adventure-api:4.26.1",
+        "net.kyori:adventure-key:4.26.1",
+        "net.kyori:adventure-nbt:4.26.1",
+        "net.kyori:adventure-text-serializer-plain:4.26.1",
+        "net.kyori:adventure-text-serializer-legacy:4.26.1",
+        "net.kyori:adventure-text-serializer-gson:4.26.1",
+        "net.kyori:adventure-text-serializer-json:4.26.1",
+        "net.kyori:adventure-text-minimessage:4.26.1",
+        "net.kyori:adventure-text-logger-slf4j:4.26.1",
+        "com.github.KyoriPowered.event:event-api:master-SNAPSHOT",
     ).forEach { include(it) }
 }
 
 tasks {
-    val remapProductionJar by registering(RemapJarTask::class) {
-        listOf(shadowJar, remapJar).forEach {
-            dependsOn(it)
-            mustRunAfter(it)
-        }
-
-        inputFile.set(shadowJar.flatMap { it.archiveFile })
-
-        archiveBaseName.set("Impactor-${project.name.capitalize()}")
-        archiveVersion.set(writeVersion(true))
-    }
-
-    val minecraft = rootProject.property("minecraft")
-
     shadowJar {
         archiveBaseName.set("Impactor-${project.name}")
         archiveClassifier.set("dev-shadow")
@@ -121,19 +105,14 @@ tasks {
             "org.apache.maven"
         ).forEach { relocate(it, "$prefix.$it") }
     }
-
-    remapJar {
-        archiveBaseName.set("Impactor-${project.name.capitalize()}")
-        archiveVersion.set("${minecraft}-${rootProject.version}")
-    }
 }
 
 tasks.withType<PublishToMavenRepository> {
-    dependsOn(tasks["remapProductionJar"])
+    dependsOn(tasks["shadowJar"])
 }
 
 tasks.withType<GenerateModuleMetadata> {
-    dependsOn(tasks["remapProductionJar"])
+    dependsOn(tasks["shadowJar"])
 }
 
 tasks.modrinth {
@@ -143,11 +122,11 @@ tasks.modrinth {
 modrinth {
     token.set(System.getenv("MODRINTH_GRADLE_TOKEN"))
     projectId.set("Impactor")
-    versionNumber.set("${writeVersion(true)}-${project.name.capitalized()}")
+    versionNumber.set("${writeVersion(true)}-${project.name}")
     versionName.set("Impactor ${writeVersion(true)}")
 
     versionType.set(if(!isRelease()) "beta" else "release")
-    uploadFile.set(tasks["remapProductionJar"])
+    uploadFile.set(tasks["shadowJar"])
 
     gameVersions.set(listOf(rootProject.property("minecraft").toString()))
 

--- a/build-logic/src/main/kotlin/impactor.launcher-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/impactor.launcher-conventions.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("impactor.loom-conventions")
 
     id("com.modrinth.minotaur")
-    id("com.github.johnrengelman.shadow")
+    id("com.gradleup.shadow")
 }
 
 val bundle: Configuration by configurations.creating {

--- a/build-logic/src/main/kotlin/impactor.launcher-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/impactor.launcher-conventions.gradle.kts
@@ -62,8 +62,13 @@ dependencies {
 
 tasks {
     shadowJar {
+        dependsOn(tasks.jar)
         archiveBaseName.set("Impactor-${project.name}")
         archiveClassifier.set("dev-shadow")
+
+        from(
+            zipTree(tasks.jar.get().archiveFile.get().asFile)
+        )
 
         dependencies {
             include(project(":api:core"))

--- a/build-logic/src/main/kotlin/impactor.loom-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/impactor.loom-conventions.gradle.kts
@@ -1,18 +1,18 @@
 plugins {
     id("impactor.base-conventions")
-    id("dev.architectury.loom")
+    id("dev.architectury.loom-no-remap")
     id("architectury-plugin")
 }
 
-loom {
-    silentMojangMappingsLicense()
+//loom {
+//    silentMojangMappingsLicense()
 
 //    val identifier: String = project.findProperty("identifier")?.toString() ?: project.name
 //    mixin.defaultRefmapName.set("mixins.impactor.$identifier.refmap.json")
 //    mixin.useLegacyMixinAp.set(false)
-}
+//}
 
 dependencies {
     minecraft("com.mojang:minecraft:${rootProject.property("minecraft")}")
-    mappings(loom.officialMojangMappings())
+//    mappings(loom.officialMojangMappings())
 }

--- a/build-logic/src/main/kotlin/impactor.loom-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/impactor.loom-conventions.gradle.kts
@@ -4,15 +4,6 @@ plugins {
     id("architectury-plugin")
 }
 
-//loom {
-//    silentMojangMappingsLicense()
-
-//    val identifier: String = project.findProperty("identifier")?.toString() ?: project.name
-//    mixin.defaultRefmapName.set("mixins.impactor.$identifier.refmap.json")
-//    mixin.useLegacyMixinAp.set(false)
-//}
-
 dependencies {
     minecraft("com.mojang:minecraft:${rootProject.property("minecraft")}")
-//    mappings(loom.officialMojangMappings())
 }

--- a/build-logic/src/main/kotlin/impactor.root-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/impactor.root-conventions.gradle.kts
@@ -34,13 +34,13 @@ tasks {
         dependsOn(changelog)
         doLast {
             val plugin = this.project.rootProject.property("plugin")
-            val target = this.project.projectDir.toPath().resolve("$buildDir").resolve("deploy").resolve("$plugin.md")
-            if(!Files.exists(target)) {
-                Files.createDirectories(target.parent)
-                Files.createFile(target)
+            val target = getLayout().buildDirectory.dir("deploy").get().file("$plugin.md")
+            if(!target.asFile.exists()) {
+                target.asFile.parentFile?.mkdirs()
+                target.asFile.createNewFile()
             }
 
-            Files.write(target, changelog.get().result.encodeToByteArray())
+            target.asFile.writeText(changelog.get().result)
         }
     }
 

--- a/build-logic/src/main/kotlin/impactor.root-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/impactor.root-conventions.gradle.kts
@@ -19,8 +19,8 @@ tasks {
 
     val collect by registering(Copy::class) {
         val filters = mapOf(
-            ":launchers:fabric" to "remapProductionJar",
-            ":launchers:neoforge" to "remapProductionJar",
+            ":launchers:fabric" to "shadowJar",
+            ":launchers:neoforge" to "shadowJar",
         )
 
         val tasks = subprojects.filter { filters.containsKey(it.path) }.map { it.tasks.named(filters.getValue(it.path)) }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,9 +1,9 @@
 plugins {
     base
     id("impactor.root-conventions")
-    id("architectury-plugin") version "3.4-SNAPSHOT" apply false
-    id("dev.architectury.loom") version "1.7-SNAPSHOT" apply false
-    id("org.spongepowered.gradle.vanilla") version "0.2.1-SNAPSHOT" apply false
+    id("architectury-plugin") version "3.5-SNAPSHOT" apply false
+    id("dev.architectury.loom-no-remap") version "1.17-SNAPSHOT" apply false
+    id("org.spongepowered.gradle.vanilla") version "0.3.2-SNAPSHOT" apply false
 }
 
 group = "net.impactdev.impactor"

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,10 +3,10 @@ org.gradle.parallel=false
 
 # Project Versions
 plugin=5.3.6
-minecraft=1.21.1
-neoforge=21.1.66
-fabric-loader=0.16.9
-fabric-api=0.107.0+1.21.1
+minecraft=26.1.2
+neoforge=26.1.2.75
+fabric-loader=0.18.4
+fabric-api=0.151.0+26.1.2
 
 # Is the project currently in a snapshot state?
 snapshot = true

--- a/gradle/libs.versions.yml
+++ b/gradle/libs.versions.yml
@@ -7,7 +7,7 @@ versions:
 
   # plugins
   licenser: 0.6.1
-  shadow: 9.0.0-beta12
+  shadow: 9.4.2
   blossom: 2.2.0
   loom: 1.17-SNAPSHOT
   architectury-plugin: 3.5-SNAPSHOT

--- a/gradle/libs.versions.yml
+++ b/gradle/libs.versions.yml
@@ -7,7 +7,7 @@ versions:
 
   # plugins
   licenser: 0.6.1
-  shadow: 8.1.1
+  shadow: 9.0.0-beta12
   blossom: 2.2.0
   loom: 1.17-SNAPSHOT
   architectury-plugin: 3.5-SNAPSHOT
@@ -72,8 +72,8 @@ dependencies:
     name: licenser
     version: { ref: licenser }
   shadow:
-    group: com.github.johnrengelman
-    name: shadow
+    group: com.gradleup.shadow
+    name: shadow-gradle-plugin
     version: { ref: shadow }
   blossom:
     group: net.kyori

--- a/gradle/libs.versions.yml
+++ b/gradle/libs.versions.yml
@@ -1,32 +1,31 @@
 versions:
 
   # jetbains
-  kotlin: 1.7.10
-  coroutines: 1.6.1
-  annotations: 23.0.0
-  serialization: 1.3.2
+  kotlin: 2.4.0
+  annotations: 26.1.0
+  serialization: 1.11.0
 
   # plugins
   licenser: 0.6.1
   shadow: 8.1.1
-  blossom: 2.1.0
-  loom: 1.7-SNAPSHOT
-  architectury-plugin: 3.4-SNAPSHOT
+  blossom: 2.2.0
+  loom: 1.17-SNAPSHOT
+  architectury-plugin: 3.5-SNAPSHOT
   minotaur: 2.+
 
   # fabric/remap
-  fabric-loader: 0.14.16
-  fabric-api: 0.92.0+1.20.1
+  fabric-loader: 0.18.4
+  fabric-api: 0.151.0+26.1.2
 
   # forge
   forge: 1.19.2-43.2.0
-  neoforge: 21.1.66
+  neoforge: 26.1.2.75
 
   # sponge
   sponge-gradle: 0.2.1-SNAPSHOT
 
   # architectury
-  architectury: 6.3.49
+  architectury: 20.0.6
 
   # test
   junit: 5.9.0
@@ -42,9 +41,8 @@ versions:
   gson: 2.10.1
 
   # Adventure
-  adventure: 4.17.0
-  adventure-fabric: 5.14.1 # 1.21.1
-  examination: 1.3.0
+  adventure: 5.1.1
+  adventure-fabric: 6.9.0 # 26.1.x
 
 dependencies:
 
@@ -52,6 +50,22 @@ dependencies:
   kotlin:
     group: org.jetbrains.kotlin
     name: kotlin-gradle-plugin
+    version: { ref: kotlin }
+  kotlinReflect:
+    group: org.jetbrains.kotlin
+    name: kotlin-reflect
+    version: { ref: kotlin }
+  kotlinStdlib:
+    group: org.jetbrains.kotlin
+    name: kotlin-stdlib
+    version: { ref: kotlin }
+  kotlinStdlib7:
+    group: org.jetbrains.kotlin
+    name: kotlin-stdlib-jdk7
+    version: { ref: kotlin }
+  kotlinStdlib8:
+    group: org.jetbrains.kotlin
+    name: kotlin-stdlib-jdk8
     version: { ref: kotlin }
   licenser:
     group: gradle.plugin.org.cadixdev.gradle
@@ -66,8 +80,8 @@ dependencies:
     name: blossom
     version: { ref: blossom }
   loom:
-    group: dev.architectury
-    name: architectury-loom
+    group: dev.architectury.loom-no-remap
+    name: dev.architectury.loom-no-remap.gradle.plugin
     version: { ref: loom }
   minotaur:
     group: com.modrinth.minotaur
@@ -236,9 +250,9 @@ dependencies:
     group: net.kyori
     name: adventure-text-logger-slf4j
     version: { ref: adventure }
-  adventureFabric:
+  adventurePlatformModShared:
     group: net.kyori
-    name: adventure-platform-fabric
+    name: adventure-platform-mod-shared
     version: { ref: adventure-fabric }
 
   # Utilities

--- a/gradle/libs.versions.yml
+++ b/gradle/libs.versions.yml
@@ -7,7 +7,7 @@ versions:
 
   # plugins
   licenser: 0.6.1
-  shadow: 8.1.1
+  shadow: 9.4.2
   blossom: 2.2.0
   loom: 1.17-SNAPSHOT
   architectury-plugin: 3.5-SNAPSHOT
@@ -72,8 +72,8 @@ dependencies:
     name: licenser
     version: { ref: licenser }
   shadow:
-    group: com.github.johnrengelman
-    name: shadow
+    group: com.gradleup.shadow
+    name: com.gradleup.shadow.gradle.plugin
     version: { ref: shadow }
   blossom:
     group: net.kyori

--- a/gradle/libs.versions.yml
+++ b/gradle/libs.versions.yml
@@ -9,7 +9,7 @@ versions:
   licenser: 0.6.1
   shadow: 9.4.2
   blossom: 2.2.0
-  loom: 1.17-SNAPSHOT
+  loom: 1.17.480
   architectury-plugin: 3.5-SNAPSHOT
   minotaur: 2.+
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Thu Apr 30 20:08:58 MST 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists

--- a/impactor/build.gradle.kts
+++ b/impactor/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
 
 repositories {
     mavenCentral()
+    mavenLocal()
 }
 
 dependencies {
@@ -20,7 +21,7 @@ dependencies {
     api(project(":api:text"))
     api(project(":api:translations"))
 
-    api("net.impactdev.impactor.api:commands:5.3.1+1.21.1") {
+    api("net.impactdev.impactor.api:commands:5.3.1+26.1.2") {
         exclude("net.impactdev.impactor.api", "core")
         exclude("net.impactdev.impactor.api", "items")
         exclude("net.impactdev.impactor.api", "players")

--- a/impactor/build.gradle.kts
+++ b/impactor/build.gradle.kts
@@ -26,6 +26,9 @@ dependencies {
         exclude("net.impactdev.impactor.api", "players")
     }
 
+    implementation("org.incendo:cloud-annotations:2.0.0")
+    implementation("org.incendo:cloud-minecraft-extras:2.0.0-beta.15")
+
     // Databases
     api("com.zaxxer:HikariCP:5.0.1")
     api("com.h2database:h2:2.1.214")
@@ -50,6 +53,7 @@ dependencies {
 
     testImplementation("net.kyori:adventure-text-serializer-ansi:4.14.0")
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.2")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.9.2")
     testImplementation("org.mockito:mockito-core:5.2.0")
     testRuntimeOnly("org.apache.logging.log4j:log4j-core:2.20.0")
@@ -72,11 +76,12 @@ sourceSets {
     }
 }
 
-license {
-    exclude("**/datasize/DataSize.java")
-    exclude("**/datasize/DataSizeUtils.java")
-    exclude("**/datasize/DataUnit.java")
-}
+
+//license {
+//    exclude("**/datasize/DataSize.java")
+//    exclude("**/datasize/DataSizeUtils.java")
+//    exclude("**/datasize/DataUnit.java")
+//}
 
 publishing {
     publications {

--- a/launchers/fabric/build.gradle.kts
+++ b/launchers/fabric/build.gradle.kts
@@ -15,16 +15,16 @@ repositories {
 }
 
 dependencies {
-    modImplementation("net.fabricmc:fabric-loader:${rootProject.property("fabric-loader")}")
+    implementation("net.fabricmc:fabric-loader:${rootProject.property("fabric-loader")}")
     listOf(
         "fabric-lifecycle-events-v1",
         "fabric-command-api-v2",
         "fabric-networking-api-v1",
-    ).forEach { modImplementation(fabricApi.module(it, rootProject.property("fabric-api").toString())) }
+    ).forEach { implementation(fabricApi.module(it, rootProject.property("fabric-api").toString())) }
 
     implementation(project(":minecraft:impl"))
-    include(modImplementation("ca.landonjw.gooeylibs:fabric-api-repack:3.1.0-1.21.1-SNAPSHOT")!!)
-    include(modImplementation("net.impactdev.impactor.commands:fabric:5.3.1+1.21.1") {
+    include(implementation("com.github.ApolloNetworkMC:GooeyLibs:26.1.2-SNAPSHOT")!!)
+    include(implementation("net.impactdev.impactor.commands:fabric:5.3.1+1.21.1") {
         exclude("net.impactdev.impactor.api", "config")
         exclude("net.impactdev.impactor.api", "core")
         exclude("net.impactdev.impactor.api", "items")
@@ -40,13 +40,13 @@ dependencies {
         libs.cloudProcessorsCommon,
     ).forEach { include(it) }
 
-    modImplementation(libs.adventureFabric)
-    include(libs.adventureFabric)
+    implementation(libs.adventurePlatformModShared)
+    include(libs.adventurePlatformModShared)
 
-    include(modImplementation("eu.pb4:placeholder-api:2.4.1+1.21")!!)
+    include(implementation("eu.pb4:placeholder-api:3.0.0+26.1")!!)
     include("io.leangen.geantyref:geantyref:1.3.13")
 
-    modRuntimeOnly("me.lucko:fabric-permissions-api:0.2-SNAPSHOT")
+    runtimeOnly("me.lucko:fabric-permissions-api:0.2-SNAPSHOT")
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.8.1")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.8.1")
 }
@@ -72,7 +72,7 @@ tasks {
 publishing {
     publications {
         create<MavenPublication>(project.name) {
-            artifact(tasks.remapProductionJar)
+            artifact(tasks.shadowJar)
 
             groupId = "net.impactdev.impactor.launchers"
             artifactId = "fabric"

--- a/launchers/fabric/build.gradle.kts
+++ b/launchers/fabric/build.gradle.kts
@@ -23,7 +23,7 @@ dependencies {
     ).forEach { implementation(fabricApi.module(it, rootProject.property("fabric-api").toString())) }
 
     implementation(project(":minecraft:impl"))
-    include(implementation("com.github.ApolloNetworkMC:GooeyLibs:26.1.2-SNAPSHOT")!!)
+    include(implementation("com.github.ApolloNetworkMC.GooeyLibs:fabric:26.1.2-SNAPSHOT")!!)
     include(implementation("net.impactdev.impactor.commands:fabric:5.3.1+1.21.1") {
         exclude("net.impactdev.impactor.api", "config")
         exclude("net.impactdev.impactor.api", "core")

--- a/launchers/fabric/src/main/java/net/impactdev/impactor/fabric/FabricAdventureTranslator.java
+++ b/launchers/fabric/src/main/java/net/impactdev/impactor/fabric/FabricAdventureTranslator.java
@@ -27,22 +27,22 @@ package net.impactdev.impactor.fabric;
 
 import net.impactdev.impactor.minecraft.api.items.AdventureTranslator;
 import net.kyori.adventure.key.Key;
-import net.kyori.adventure.platform.fabric.FabricAudiences;
-import net.kyori.adventure.platform.fabric.FabricServerAudiences;
+import net.kyori.adventure.platform.modcommon.MinecraftAudiences;
+import net.kyori.adventure.platform.modcommon.MinecraftServerAudiences;
 import net.kyori.adventure.text.Component;
-import net.minecraft.resources.ResourceLocation;
+import net.minecraft.resources.Identifier;
 import net.minecraft.server.MinecraftServer;
 
 public class FabricAdventureTranslator implements AdventureTranslator {
 
     @Override
-    public Key asAdventure(ResourceLocation location) {
-        return FabricAudiences.toAdventure(location);
+    public Key asAdventure(Identifier location) {
+        return MinecraftAudiences.asAdventure(location);
     }
 
     @Override
-    public ResourceLocation asNative(Key key) {
-        return FabricAudiences.toNative(key);
+    public Identifier asNative(Key key) {
+        return MinecraftAudiences.asNative(key);
     }
 
     @Override
@@ -50,16 +50,16 @@ public class FabricAdventureTranslator implements AdventureTranslator {
         return "Neoforge Adventure Platform Translator";
     }
 
-    public record FabricServerTranslator(FabricServerAudiences translator) implements Server {
+    public record FabricServerTranslator(MinecraftServerAudiences translator) implements Server {
 
         @Override
         public Component asAdventure(net.minecraft.network.chat.Component component) {
-            return this.translator.toAdventure(component);
+            return this.translator.asAdventure(component);
         }
 
         @Override
         public net.minecraft.network.chat.Component asNative(Component component) {
-            return this.translator.toNative(component);
+            return this.translator.asNative(component);
         }
 
     }
@@ -68,7 +68,7 @@ public class FabricAdventureTranslator implements AdventureTranslator {
 
         @Override
         public Server create(MinecraftServer server) {
-            return new FabricServerTranslator(FabricServerAudiences.of(server));
+            return new FabricServerTranslator(MinecraftServerAudiences.of(server));
         }
 
     }

--- a/launchers/fabric/src/main/java/net/impactdev/impactor/fabric/commands/PAPITestCommand.java
+++ b/launchers/fabric/src/main/java/net/impactdev/impactor/fabric/commands/PAPITestCommand.java
@@ -26,12 +26,14 @@
 package net.impactdev.impactor.fabric.commands;
 
 import eu.pb4.placeholders.api.PlaceholderContext;
+import eu.pb4.placeholders.api.PlaceholderResult;
 import eu.pb4.placeholders.api.Placeholders;
 import net.impactdev.impactor.api.commands.CommandSource;
 import net.impactdev.impactor.fabric.FabricImpactorBootstrap;
 import net.impactdev.impactor.minecraft.api.items.AdventureTranslator;
 import net.impactdev.impactor.minecraft.api.items.ServerProvider;
 import net.minecraft.network.chat.Component;
+import net.minecraft.resources.Identifier;
 import net.minecraft.server.level.ServerPlayer;
 import org.incendo.cloud.annotation.specifier.Greedy;
 import org.incendo.cloud.annotations.Argument;
@@ -51,11 +53,11 @@ public final class PAPITestCommand {
             return;
         }
 
-        Component input = Component.literal(placeholder);
-        Component result = Placeholders.parseText(input, PlaceholderContext.of(minecraft));
+        Identifier input = Identifier.parse(placeholder);
+        PlaceholderResult result = Placeholders.parseCommonPlaceholder(input, null, PlaceholderContext.of(minecraft));
 
         AdventureTranslator.Server translator = AdventureTranslator.Server.get(ServerProvider.server());
-        source.sendMessage(translator.asAdventure(result));
+        source.sendMessage(translator.asAdventure(result.component()));
     }
 
 }

--- a/launchers/fabric/src/main/java/net/impactdev/impactor/fabric/integrations/PlaceholderAPIIntegration.java
+++ b/launchers/fabric/src/main/java/net/impactdev/impactor/fabric/integrations/PlaceholderAPIIntegration.java
@@ -43,8 +43,9 @@ import net.impactdev.impactor.minecraft.api.items.ServerProvider;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
 import net.kyori.event.EventBus;
-import net.minecraft.resources.ResourceLocation;
+import net.minecraft.resources.Identifier;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import org.jetbrains.annotations.Nullable;
 
@@ -60,7 +61,7 @@ public final class PlaceholderAPIIntegration {
         logger.info("Integrating with PlaceholderAPI...");
 
         bus.subscribe(RegisterPlaceholdersEvent.class, event -> {
-            Placeholders.getPlaceholders().forEach((location, handler) -> {
+            Placeholders.getCommonPlaceholders().forEach((location, handler) -> {
                 Key key = Key.key(location.toString());
                 if(key.namespace().equals("impactor")) {
                     return;
@@ -81,12 +82,12 @@ public final class PlaceholderAPIIntegration {
                     if (player != null) {
                         ctx = PlaceholderContext.of(player);
                     } else {
-                        ctx = PlaceholderContext.of(server);
+                        ctx = PlaceholderContext.of(server.overworld());
                     }
 
                     AdventureTranslator.Server translator = AdventureTranslator.Server.get(ServerProvider.server());
                     return translator.asAdventure(handler.onPlaceholderRequest(ctx,
-                            arguments.popOrDefault()).text());
+                            arguments.popOrDefault()).component());
                 });
             });
         });
@@ -95,7 +96,7 @@ public final class PlaceholderAPIIntegration {
     public void registerToPapi() {
         PlaceholderService placeholders = Impactor.instance().services().provide(PlaceholderService.class);
         placeholders.parsers().forEach((key, parser) -> {
-            Placeholders.register(ResourceLocation.fromNamespaceAndPath(key.namespace(), key.value()), (context, argument) -> {
+            Placeholders.registerCommon(Identifier.fromNamespaceAndPath(key.namespace(), key.value()), (context, argument) -> {
                 Context ctx = Context.empty();
                 if(argument != null) {
                     ctx.append(PlaceholderArguments.class, new PlaceholderArguments(new String[]{ argument }));
@@ -120,7 +121,7 @@ public final class PlaceholderAPIIntegration {
     private PlatformSource viewer(PlaceholderContext context) {
         if(context.hasPlayer()) {
             return PlatformPlayer.getOrCreate(context.player().getUUID());
-        } else if(context.server() != null) {
+        } else if(context.level() != null && context.level() instanceof ServerLevel) {
             return PlatformSource.server();
         } else if(context.hasEntity()) {
             return PlatformSource.factory().fromID(context.entity().getUUID());

--- a/launchers/fabric/src/main/java/net/impactdev/impactor/fabric/platform/components/FabricMinecraftComponent.java
+++ b/launchers/fabric/src/main/java/net/impactdev/impactor/fabric/platform/components/FabricMinecraftComponent.java
@@ -32,7 +32,7 @@ public final class FabricMinecraftComponent extends MinecraftPlatformComponent {
 
     @Override
     public String version() {
-        return SharedConstants.getCurrentVersion().getName();
+        return SharedConstants.getCurrentVersion().name();
     }
 
 }

--- a/launchers/fabric/src/main/java/net/impactdev/impactor/fabric/platform/sources/FabricPlatformFactory.java
+++ b/launchers/fabric/src/main/java/net/impactdev/impactor/fabric/platform/sources/FabricPlatformFactory.java
@@ -39,8 +39,9 @@ import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
-import net.minecraft.server.players.GameProfileCache;
+import net.minecraft.server.players.NameAndId;
 import net.minecraft.server.players.PlayerList;
+import net.minecraft.server.players.UserNameToIdResolver;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.Vec2;
@@ -73,8 +74,8 @@ public class FabricPlatformFactory implements PlatformSource.Factory, PlatformPl
             MinecraftServer server = FabricImpactorBootstrap.instance().server().get();
             PlayerList players = server.getPlayerList();
             ServerPlayer player = players.getPlayer(id);
-            GameProfileCache cache = server.getProfileCache();
-            Optional<GameProfile> profile = cache.get(uuid);
+            UserNameToIdResolver cache = server.services().nameToIdCache();
+            Optional<NameAndId> profile = cache.get(uuid);
 
             if(player != null || profile.isPresent()) {
                 return new FabricPlatformPlayer(id);
@@ -86,7 +87,7 @@ public class FabricPlatformFactory implements PlatformSource.Factory, PlatformPl
                     PlatformSource source = new FabricPlatformSource(id, SourceType.ENTITY);
                     source.offer(MetadataKeys.WORLD, () -> {
                         ResourceKey<Level> key = level.dimension();
-                        return Key.key(key.location().getNamespace(), key.location().getPath());
+                        return Key.key(key.identifier().getNamespace(), key.identifier().getPath());
                     });
                     source.offer(GameMetadataKeys.ENTITY, () -> entity);
                     source.offer(MetadataKeys.POSITION, () -> {

--- a/launchers/fabric/src/main/java/net/impactdev/impactor/fabric/ui/gooey/GooeyIcon.java
+++ b/launchers/fabric/src/main/java/net/impactdev/impactor/fabric/ui/gooey/GooeyIcon.java
@@ -43,7 +43,7 @@ public final class GooeyIcon extends GooeyButton {
             Context context = Context.empty();
             context.with(icon.context())
                     .append(ImpactorItemStack.class, icon.display().get())
-                    .append(PlatformPlayer.class, PlatformPlayer.getOrCreate(action.getPlayer().getUUID()))
+                    .append(PlatformPlayer.class, PlatformPlayer.getOrCreate(action.getPlayer().nameAndId().id()))
                     .append(ButtonClick.class, action.getClickType())
                     .append(Integer.class, action.getSlot());
 

--- a/launchers/forge/build.gradle.kts
+++ b/launchers/forge/build.gradle.kts
@@ -19,20 +19,21 @@ loom {
 
 repositories {
     maven(url = "https://maven.neoforged.net/releases")
+    mavenLocal()
 }
 
 dependencies {
     neoForge(libs.neoforge)
 
     implementation(project(":minecraft:impl"))
-    include(modImplementation("ca.landonjw.gooeylibs:api:3.1.0-1.21.1-SNAPSHOT")!!)
+    include(implementation("com.github.ApolloNetworkMC:GooeyLibs:26.1.2-SNAPSHOT")!!)
 
     compileOnly("com.google.auto.service:auto-service-annotations:1.1.1")
     annotationProcessor("com.google.auto.service:auto-service:1.1.1")
 
     include("io.leangen.geantyref:geantyref:1.3.13")
 
-    include(modImplementation("net.impactdev.impactor.commands:neoforge:5.3.1+1.21.1") {
+    include(implementation("net.impactdev.impactor.commands:neoforge:5.3.1+1.21.1") {
         exclude("net.impactdev.impactor.api", "config")
         exclude("net.impactdev.impactor.api", "core")
         exclude("net.impactdev.impactor.api", "items")
@@ -48,7 +49,7 @@ dependencies {
         libs.cloudMinecraftExtras,
     ).forEach { include(it) }
 
-    include(modImplementation("net.kyori:adventure-platform-neoforge:6.0.0")!!)
+    include(implementation("net.kyori:adventure-platform-neoforge:6.9.0")!!)
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.8.1")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.8.1")
@@ -78,7 +79,7 @@ tasks {
 publishing {
     publications {
         create<MavenPublication>(project.name) {
-            artifact(tasks.remapProductionJar)
+            artifact(tasks.shadowJar)
 
             groupId = "net.impactdev.impactor.launchers"
             artifactId = "neoforge"

--- a/launchers/forge/build.gradle.kts
+++ b/launchers/forge/build.gradle.kts
@@ -5,6 +5,11 @@ plugins {
     id("impactor.publishing-conventions")
 }
 
+architectury {
+    platformSetupLoomIde()
+    neoForge()
+}
+
 loom {
     neoForge {
         runs {
@@ -26,7 +31,8 @@ dependencies {
     neoForge(libs.neoforge)
 
     implementation(project(":minecraft:impl"))
-    include(implementation("com.github.ApolloNetworkMC:GooeyLibs:26.1.2-SNAPSHOT")!!)
+    include(implementation("com.github.ApolloNetworkMC.GooeyLibs:neoforge:26.1.2-SNAPSHOT")!!)
+    implementation("com.github.ApolloNetworkMC.GooeyLibs:api:26.1.2-SNAPSHOT")
 
     compileOnly("com.google.auto.service:auto-service-annotations:1.1.1")
     annotationProcessor("com.google.auto.service:auto-service:1.1.1")

--- a/launchers/forge/build.gradle.kts
+++ b/launchers/forge/build.gradle.kts
@@ -39,7 +39,7 @@ dependencies {
 
     include("io.leangen.geantyref:geantyref:1.3.13")
 
-    include(implementation("net.impactdev.impactor.commands:neoforge:5.3.1+1.21.1") {
+    include(implementation("net.impactdev.impactor.commands:neoforge:5.3.1+26.1.2") {
         exclude("net.impactdev.impactor.api", "config")
         exclude("net.impactdev.impactor.api", "core")
         exclude("net.impactdev.impactor.api", "items")

--- a/launchers/forge/build.gradle.kts
+++ b/launchers/forge/build.gradle.kts
@@ -74,10 +74,19 @@ tasks {
     }
 
     processResources {
+        val minecraft: String = rootProject.property("minecraft") as String
+        val neoforge: String = rootProject.property("neoforge") as String
+
         inputs.property("version", writeVersion(true))
+        inputs.property("minecraft", minecraft)
+        inputs.property("neoforge", neoforge)
 
         filesMatching("META-INF/neoforge.mods.toml") {
-            expand("version" to writeVersion(true))
+            expand(
+                "version" to writeVersion(true),
+                "minecraft" to minecraft,
+                "neoforge" to neoforge
+            )
         }
     }
 }

--- a/launchers/forge/build.gradle.kts
+++ b/launchers/forge/build.gradle.kts
@@ -14,10 +14,10 @@ loom {
     neoForge {
         runs {
             val client = maybeCreate("client")
-            client.vmArgs("-Dmixin.debug.export=true")
+            client.jvmArguments.add("-Dmixin.debug.export=true")
 
             val server = maybeCreate("server")
-            server.vmArgs("-Dmixin.debug.export=true")
+            server.jvmArguments.add("-Dmixin.debug.export=true")
         }
     }
 }

--- a/launchers/forge/src/main/java/net/impactdev/impactor/forge/NeoforgeAdventureTranslator.java
+++ b/launchers/forge/src/main/java/net/impactdev/impactor/forge/NeoforgeAdventureTranslator.java
@@ -30,18 +30,18 @@ import net.kyori.adventure.key.Key;
 import net.kyori.adventure.platform.modcommon.MinecraftAudiences;
 import net.kyori.adventure.platform.modcommon.MinecraftServerAudiences;
 import net.kyori.adventure.text.Component;
-import net.minecraft.resources.ResourceLocation;
+import net.minecraft.resources.Identifier;
 import net.minecraft.server.MinecraftServer;
 
 public class NeoforgeAdventureTranslator implements AdventureTranslator {
 
     @Override
-    public Key asAdventure(ResourceLocation location) {
+    public Key asAdventure(Identifier location) {
         return MinecraftAudiences.asAdventure(location);
     }
 
     @Override
-    public ResourceLocation asNative(Key key) {
+    public Identifier asNative(Key key) {
         return MinecraftAudiences.asNative(key);
     }
 

--- a/launchers/forge/src/main/java/net/impactdev/impactor/forge/listeners/ConnectionListener.java
+++ b/launchers/forge/src/main/java/net/impactdev/impactor/forge/listeners/ConnectionListener.java
@@ -30,7 +30,7 @@ import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.event.entity.player.PlayerEvent;
 
-@EventBusSubscriber(bus = EventBusSubscriber.Bus.GAME)
+@EventBusSubscriber
 public class ConnectionListener {
 
     @SubscribeEvent

--- a/launchers/forge/src/main/java/net/impactdev/impactor/forge/platform/components/ForgeComponent.java
+++ b/launchers/forge/src/main/java/net/impactdev/impactor/forge/platform/components/ForgeComponent.java
@@ -27,7 +27,7 @@ package net.impactdev.impactor.forge.platform.components;
 
 import net.impactdev.impactor.api.platform.PlatformComponent;
 import net.impactdev.impactor.api.utility.printing.PrettyPrinter;
-import net.neoforged.neoforge.internal.versions.neoforge.NeoForgeVersion;
+import net.neoforged.neoforge.common.NeoForgeVersion;
 
 public class ForgeComponent implements PlatformComponent {
 

--- a/launchers/forge/src/main/java/net/impactdev/impactor/forge/platform/components/ForgeMinecraftComponent.java
+++ b/launchers/forge/src/main/java/net/impactdev/impactor/forge/platform/components/ForgeMinecraftComponent.java
@@ -32,7 +32,7 @@ public final class ForgeMinecraftComponent extends MinecraftPlatformComponent {
 
     @Override
     public String version() {
-        return SharedConstants.getCurrentVersion().getName();
+        return SharedConstants.getCurrentVersion().name();
     }
 
 }

--- a/launchers/forge/src/main/java/net/impactdev/impactor/forge/platform/sources/ForgePlatformFactory.java
+++ b/launchers/forge/src/main/java/net/impactdev/impactor/forge/platform/sources/ForgePlatformFactory.java
@@ -77,7 +77,7 @@ public class ForgePlatformFactory implements PlatformSource.Factory, PlatformPla
                     PlatformSource source = new ForgePlatformSource(id, SourceType.ENTITY);
                     source.offer(MetadataKeys.WORLD, () -> {
                         ResourceKey<Level> key = level.dimension();
-                        return Key.key(key.location().getNamespace(), key.location().getPath());
+                        return Key.key(key.identifier().getNamespace(), key.identifier().getPath());
                     });
                     source.offer(GameMetadataKeys.ENTITY, () -> entity);
                     source.offer(MetadataKeys.POSITION, () -> {

--- a/launchers/forge/src/main/java/net/impactdev/impactor/forge/platform/sources/ForgePlatformPlayerService.java
+++ b/launchers/forge/src/main/java/net/impactdev/impactor/forge/platform/sources/ForgePlatformPlayerService.java
@@ -39,7 +39,7 @@ public final class ForgePlatformPlayerService extends ImpactorPlatformPlayerServ
         return ImmutableSet.copyOf(ServerLifecycleHooks.getCurrentServer().getPlayerList()
                 .getPlayers()
                 .stream()
-                .map(player -> this.getOrCreate(player.getUUID()))
+                .map(player -> this.getOrCreate(player.nameAndId().id()))
                 .collect(Collectors.toSet()));
     }
 }

--- a/launchers/forge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/launchers/forge/src/main/resources/META-INF/neoforge.mods.toml
@@ -11,13 +11,13 @@ description = "General Purpose Minecraft API"
 [[dependencies.impactor]]
 modId = "minecraft"
 mandatory = true
-versionRange = "[1.21.1]"
+versionRange = "[${minecraft}]"
 ordering = "NONE"
 side = "BOTH"
 
 [[dependencies.impactor]]
 modId = "neoforge"
 mandatory = true
-versionRange = "[21.1.6,)"
+versionRange = "[${neoforge},)"
 ordering = "NONE"
 side = "BOTH"

--- a/minecraft/api/build.gradle.kts
+++ b/minecraft/api/build.gradle.kts
@@ -2,17 +2,13 @@ import extensions.writeVersion
 
 plugins {
     id("impactor.base-conventions")
+    id("impactor.loom-conventions")
     id("impactor.publishing-conventions")
-    id("org.spongepowered.gradle.vanilla")
 }
 
 repositories {
     mavenCentral()
     maven("https://oss.sonatype.org/content/repositories/snapshots")
-}
-
-minecraft {
-    version("${rootProject.property("minecraft")}")
 }
 
 dependencies {

--- a/minecraft/api/src/main/java/net/impactdev/impactor/minecraft/api/items/AdventureTranslator.java
+++ b/minecraft/api/src/main/java/net/impactdev/impactor/minecraft/api/items/AdventureTranslator.java
@@ -29,7 +29,7 @@ import net.impactdev.impactor.api.Impactor;
 import net.impactdev.impactor.api.services.Service;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
-import net.minecraft.resources.ResourceLocation;
+import net.minecraft.resources.Identifier;
 import net.minecraft.server.MinecraftServer;
 
 public interface AdventureTranslator extends Service {
@@ -56,8 +56,8 @@ public interface AdventureTranslator extends Service {
 
     }
 
-    Key asAdventure(ResourceLocation location);
+    Key asAdventure(Identifier location);
 
-    ResourceLocation asNative(Key key);
+    Identifier asNative(Key key);
 
 }

--- a/minecraft/impl/build.gradle.kts
+++ b/minecraft/impl/build.gradle.kts
@@ -2,17 +2,13 @@ import extensions.writeVersion
 
 plugins {
     id("impactor.base-conventions")
+    id("impactor.loom-conventions")
     id("impactor.publishing-conventions")
-    id("org.spongepowered.gradle.vanilla")
 }
 
 repositories {
     mavenCentral()
     maven("https://oss.sonatype.org/content/repositories/snapshots")
-}
-
-minecraft {
-    version("${rootProject.property("minecraft")}")
 }
 
 dependencies {

--- a/minecraft/impl/build.gradle.kts
+++ b/minecraft/impl/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
 
     testImplementation("net.kyori:adventure-text-serializer-ansi:4.17.0")
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.2")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.9.2")
     testImplementation("net.kyori:adventure-text-logger-slf4j:4.17.0")
 }

--- a/minecraft/impl/src/main/java/net/impactdev/impactor/minecraft/items/ImpactorItemType.java
+++ b/minecraft/impl/src/main/java/net/impactdev/impactor/minecraft/items/ImpactorItemType.java
@@ -29,7 +29,7 @@ import net.impactdev.impactor.api.items.types.ItemType;
 import net.kyori.adventure.key.Key;
 import net.minecraft.core.Registry;
 import net.minecraft.core.registries.BuiltInRegistries;
-import net.minecraft.resources.ResourceLocation;
+import net.minecraft.resources.Identifier;
 import net.minecraft.world.item.Item;
 
 import java.util.Optional;
@@ -44,7 +44,7 @@ public class ImpactorItemType implements ItemType {
 
     public Optional<Item> minecraft() {
         Registry<Item> registry = BuiltInRegistries.ITEM;
-        ResourceLocation location = ResourceLocation.fromNamespaceAndPath(this.key.namespace(), this.key.value());
+        Identifier location = Identifier.fromNamespaceAndPath(this.key.namespace(), this.key.value());
         return registry.getOptional(location);
     }
 

--- a/minecraft/impl/src/main/java/net/impactdev/impactor/minecraft/items/ImpactorItemType.java
+++ b/minecraft/impl/src/main/java/net/impactdev/impactor/minecraft/items/ImpactorItemType.java
@@ -27,9 +27,11 @@ package net.impactdev.impactor.minecraft.items;
 
 import net.impactdev.impactor.api.items.types.ItemType;
 import net.kyori.adventure.key.Key;
-import net.minecraft.core.Registry;
+import net.minecraft.core.Holder;
 import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.Identifier;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.item.Item;
 
 import java.util.Optional;
@@ -42,10 +44,14 @@ public class ImpactorItemType implements ItemType {
         this.key = key;
     }
 
-    public Optional<Item> minecraft() {
-        Registry<Item> registry = BuiltInRegistries.ITEM;
+    public Optional<Holder.Reference<Item>> minecraftHolder() {
         Identifier location = Identifier.fromNamespaceAndPath(this.key.namespace(), this.key.value());
-        return registry.getOptional(location);
+        ResourceKey<Item> registry = ResourceKey.create(Registries.ITEM, location);
+        return BuiltInRegistries.ITEM.get(registry);
+    }
+
+    public Optional<Item> minecraft() {
+        return minecraftHolder().map(Holder.Reference::value);
     }
 
     @Override

--- a/minecraft/impl/src/main/java/net/impactdev/impactor/minecraft/items/stacks/ImpactorItemStackTranslator.java
+++ b/minecraft/impl/src/main/java/net/impactdev/impactor/minecraft/items/stacks/ImpactorItemStackTranslator.java
@@ -68,12 +68,12 @@ import net.minecraft.nbt.ShortTag;
 import net.minecraft.nbt.StringTag;
 import net.minecraft.nbt.Tag;
 import net.minecraft.nbt.TagType;
-import net.minecraft.resources.ResourceLocation;
+import net.minecraft.resources.Identifier;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.Unit;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.component.CustomData;
 import net.minecraft.world.item.component.ItemLore;
-import net.minecraft.world.item.component.Unbreakable;
 import net.minecraft.world.item.enchantment.ItemEnchantments;
 import net.minecraft.world.level.ItemLike;
 import org.jetbrains.annotations.NotNull;
@@ -113,17 +113,17 @@ public final class ImpactorItemStackTranslator implements ItemStackTranslator {
         }
 
         for(Enchantment enchantment : stack.enchantments()) {
-            ResourceLocation key = translator.asNative(enchantment.type());
+            Identifier key = translator.asNative(enchantment.type());
             MinecraftServer server = ServerProvider.server();
 
-            server.registries().compositeAccess().registry(Registries.ENCHANTMENT)
+            server.registries().compositeAccess().lookup(Registries.ENCHANTMENT)
                     .ifPresent(registry -> {
-                        result.enchant(registry.getHolder(key).orElseThrow(), enchantment.level());
+                        result.enchant(registry.get(key).orElseThrow(), enchantment.level());
                     });
         }
 
         if(stack.unbreakable()) {
-            result.set(DataComponents.UNBREAKABLE, new Unbreakable(true));
+            result.set(DataComponents.UNBREAKABLE, Unit.INSTANCE);
         }
 
         if(stack.nbt() != null) {
@@ -167,7 +167,7 @@ public final class ImpactorItemStackTranslator implements ItemStackTranslator {
                 Holder<net.minecraft.world.item.enchantment.Enchantment> enchantment = entry.getKey();
                 int level = entry.getIntValue();
 
-                Key target = translator.asAdventure(enchantment.unwrapKey().orElseThrow().location());
+                Key target = translator.asAdventure(enchantment.unwrapKey().orElseThrow().identifier());
 
                 builder.enchantment(Enchantment.create(target, level));
             });
@@ -182,19 +182,20 @@ public final class ImpactorItemStackTranslator implements ItemStackTranslator {
 
     private CompoundBinaryTag translateNativeNBT(CompoundTag minecraft) {
         AtomicReference<CompoundBinaryTag> result = new AtomicReference<>(CompoundBinaryTag.empty());
-        minecraft.getAllKeys().forEach(key -> {
-            @NotNull Tag tag = Objects.requireNonNull(minecraft.get(key));
+        minecraft.entrySet().forEach(pair -> {
+            final @NotNull Tag tag = Objects.requireNonNull(pair.getValue());
+            final String key = pair.getKey();
             byte type = tag.getId();
 
             switch (type) {
-                case Tag.TAG_BYTE -> result.set(result.get().putByte(key, from(ByteTag.TYPE, tag).getAsByte()));
-                case Tag.TAG_SHORT -> result.set(result.get().putShort(key, from(ShortTag.TYPE, tag).getAsShort()));
-                case Tag.TAG_INT -> result.set(result.get().putInt(key, from(IntTag.TYPE, tag).getAsInt()));
-                case Tag.TAG_LONG -> result.set(result.get().putLong(key, from(LongTag.TYPE, tag).getAsLong()));
-                case Tag.TAG_FLOAT -> result.set(result.get().putFloat(key, from(FloatTag.TYPE, tag).getAsFloat()));
-                case Tag.TAG_DOUBLE -> result.set(result.get().putDouble(key, from(DoubleTag.TYPE, tag).getAsDouble()));
+                case Tag.TAG_BYTE -> result.set(result.get().putByte(key, from(ByteTag.TYPE, tag).byteValue()));
+                case Tag.TAG_SHORT -> result.set(result.get().putShort(key, from(ShortTag.TYPE, tag).shortValue()));
+                case Tag.TAG_INT -> result.set(result.get().putInt(key, from(IntTag.TYPE, tag).intValue()));
+                case Tag.TAG_LONG -> result.set(result.get().putLong(key, from(LongTag.TYPE, tag).longValue()));
+                case Tag.TAG_FLOAT -> result.set(result.get().putFloat(key, from(FloatTag.TYPE, tag).floatValue()));
+                case Tag.TAG_DOUBLE -> result.set(result.get().putDouble(key, from(DoubleTag.TYPE, tag).doubleValue()));
                 case Tag.TAG_BYTE_ARRAY -> result.set(result.get().putByteArray(key, from(ByteArrayTag.TYPE, tag).getAsByteArray()));
-                case Tag.TAG_STRING -> result.set(result.get().putString(key, from(StringTag.TYPE, tag).getAsString()));
+                case Tag.TAG_STRING -> result.set(result.get().putString(key, from(StringTag.TYPE, tag).value()));
                 case Tag.TAG_LIST -> result.set(result.get().put(key, translateNativeListNBT(from(ListTag.TYPE, tag))));
                 case Tag.TAG_COMPOUND -> result.set(result.get().put(key, translateNativeNBT(from(CompoundTag.TYPE, tag))));
                 case Tag.TAG_INT_ARRAY -> result.set(result.get().putIntArray(key, from(IntArrayTag.TYPE, tag).getAsIntArray()));
@@ -212,12 +213,12 @@ public final class ImpactorItemStackTranslator implements ItemStackTranslator {
             byte type = tag.getId();
 
             switch (type) {
-                case Tag.TAG_BYTE -> result.set(result.get().add(toAdventure(from(ByteTag.TYPE, tag).getAsByte(), ByteBinaryTag::byteBinaryTag)));
-                case Tag.TAG_SHORT -> result.set(result.get().add(toAdventure(from(ShortTag.TYPE, tag).getAsShort(), ShortBinaryTag::shortBinaryTag)));
-                case Tag.TAG_INT -> result.set(result.get().add(toAdventure(from(IntTag.TYPE, tag).getAsInt(), IntBinaryTag::intBinaryTag)));
-                case Tag.TAG_LONG -> result.set(result.get().add(toAdventure(from(LongTag.TYPE, tag).getAsLong(), LongBinaryTag::longBinaryTag)));
-                case Tag.TAG_FLOAT -> result.set(result.get().add(toAdventure(from(FloatTag.TYPE, tag).getAsFloat(), FloatBinaryTag::floatBinaryTag)));
-                case Tag.TAG_DOUBLE -> result.set(result.get().add(toAdventure(from(DoubleTag.TYPE, tag).getAsDouble(), DoubleBinaryTag::doubleBinaryTag)));
+                case Tag.TAG_BYTE -> result.set(result.get().add(toAdventure(from(ByteTag.TYPE, tag).byteValue(), ByteBinaryTag::byteBinaryTag)));
+                case Tag.TAG_SHORT -> result.set(result.get().add(toAdventure(from(ShortTag.TYPE, tag).shortValue(), ShortBinaryTag::shortBinaryTag)));
+                case Tag.TAG_INT -> result.set(result.get().add(toAdventure(from(IntTag.TYPE, tag).intValue(), IntBinaryTag::intBinaryTag)));
+                case Tag.TAG_LONG -> result.set(result.get().add(toAdventure(from(LongTag.TYPE, tag).longValue(), LongBinaryTag::longBinaryTag)));
+                case Tag.TAG_FLOAT -> result.set(result.get().add(toAdventure(from(FloatTag.TYPE, tag).floatValue(), FloatBinaryTag::floatBinaryTag)));
+                case Tag.TAG_DOUBLE -> result.set(result.get().add(toAdventure(from(DoubleTag.TYPE, tag).doubleValue(), DoubleBinaryTag::doubleBinaryTag)));
                 case Tag.TAG_BYTE_ARRAY -> {
                     ByteArrayBinaryTag ba = toAdventure(
                             from(ByteArrayTag.TYPE, tag).getAsByteArray(),
@@ -225,7 +226,7 @@ public final class ImpactorItemStackTranslator implements ItemStackTranslator {
                     );
                     result.set(result.get().add(ba));
                 }
-                case Tag.TAG_STRING -> result.set(result.get().add(toAdventure(from(StringTag.TYPE, tag).getAsString(), StringBinaryTag::stringBinaryTag)));
+                case Tag.TAG_STRING -> result.set(result.get().add(toAdventure(from(StringTag.TYPE, tag).value(), StringBinaryTag::stringBinaryTag)));
                 case Tag.TAG_LIST -> {
                     ListBinaryTag lb = translateNativeListNBT(from(ListTag.TYPE, tag));
                     result.set(result.get().add((BinaryTag) lb));

--- a/minecraft/impl/src/main/java/net/impactdev/impactor/minecraft/items/stacks/providers/ImpactorSkullStack.java
+++ b/minecraft/impl/src/main/java/net/impactdev/impactor/minecraft/items/stacks/providers/ImpactorSkullStack.java
@@ -32,7 +32,7 @@ import net.impactdev.impactor.api.items.types.ItemTypes;
 import net.impactdev.impactor.minecraft.items.stacks.builders.ImpactorSkullStackBuilder;
 import net.kyori.adventure.nbt.CompoundBinaryTag;
 import net.kyori.adventure.nbt.ListBinaryTag;
-import net.minecraft.nbt.NbtUtils;
+import net.minecraft.core.UUIDUtil;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -87,7 +87,7 @@ public final class ImpactorSkullStack extends AbstractedItemStack implements Sku
             } else {
                 if (this.metadata.texture().isPresent()) {
                     CompoundBinaryTag owner = CompoundBinaryTag.empty();
-                    owner = owner.putIntArray("Id", NbtUtils.createUUID(UUID.randomUUID()).getAsIntArray());
+                    owner = owner.putIntArray("Id", UUIDUtil.uuidToIntArray(UUID.randomUUID()));
                     owner = this.properties(owner);
 
                     nbt = nbt.put("SkullOwner", owner);

--- a/minecraft/impl/src/main/java/net/impactdev/impactor/minecraft/platform/sources/ImpactorPlatformPlayer.java
+++ b/minecraft/impl/src/main/java/net/impactdev/impactor/minecraft/platform/sources/ImpactorPlatformPlayer.java
@@ -68,7 +68,8 @@ import net.minecraft.network.protocol.game.ClientboundStopSoundPacket;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.network.ServerGamePacketListenerImpl;
-import net.minecraft.server.players.GameProfileCache;
+import net.minecraft.server.players.NameAndId;
+import net.minecraft.server.players.UserNameToIdResolver;
 import net.minecraft.sounds.SoundEvent;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.InteractionHand;
@@ -114,7 +115,7 @@ public abstract class ImpactorPlatformPlayer extends ImpactorPlatformSource impl
         this.offer(MetadataKeys.PERMISSION_LEVEL, () -> this.asMinecraftPlayer()
                 .map(player -> {
                     MinecraftServer server = ((GamePlatform) Impactor.instance().platform()).server();
-                    if(server.getPlayerList().isOp(player.getGameProfile())) {
+                    if(server.getPlayerList().isOp(player.nameAndId())) {
                         return 4;
                     }
 
@@ -126,8 +127,8 @@ public abstract class ImpactorPlatformPlayer extends ImpactorPlatformSource impl
 
     public abstract Optional<ServerPlayer> asMinecraftPlayer();
 
-    private Optional<GameProfile> profile() {
-        GameProfileCache cache = ((GamePlatform) Impactor.instance().platform()).server().getProfileCache();
+    private Optional<NameAndId> profile() {
+        UserNameToIdResolver cache = ((GamePlatform) Impactor.instance().platform()).server().services().nameToIdCache();
         return cache.get(this.uuid());
     }
 
@@ -139,7 +140,7 @@ public abstract class ImpactorPlatformPlayer extends ImpactorPlatformSource impl
                 .map(Player::getName)
                 .map(translator::asAdventure)
                 .orElseGet(() -> this.profile()
-                        .map(GameProfile::getName)
+                        .map(NameAndId::name)
                         .map(Component::text)
                         .orElse(Component.text("Unknown"))
                 );
@@ -175,7 +176,7 @@ public abstract class ImpactorPlatformPlayer extends ImpactorPlatformSource impl
         this.asMinecraftPlayer().ifPresent(target -> {
             final ServerGamePacketListenerImpl connection = target.connection;
             final Inventory inventory = target.getInventory();
-            final int slot = inventory.items.size() + inventory.selected;
+            final int slot = inventory.getNonEquipmentItems().size() + inventory.getSelectedSlot();
 
             final BookStack item = ImpactorItemStack.book()
                     .title(GlobalTranslator.render(book.title(), this.locale()))
@@ -188,7 +189,7 @@ public abstract class ImpactorPlatformPlayer extends ImpactorPlatformSource impl
 
             connection.send(new ClientboundContainerSetSlotPacket(0, target.containerMenu.getStateId(), slot, vanilla));
             connection.send(new ClientboundOpenBookPacket(InteractionHand.MAIN_HAND));
-            connection.send(new ClientboundContainerSetSlotPacket(0, target.containerMenu.getStateId(), slot, inventory.getSelected()));
+            connection.send(new ClientboundContainerSetSlotPacket(0, target.containerMenu.getStateId(), slot, inventory.getSelectedItem()));
         });
     }
 
@@ -255,10 +256,7 @@ public abstract class ImpactorPlatformPlayer extends ImpactorPlatformSource impl
         AdventureTranslator translator = AdventureTranslator.get();
 
         this.asMinecraftPlayer().ifPresent(target -> {
-            final Optional<Holder.Reference<SoundEvent>> reference = BuiltInRegistries.SOUND_EVENT.holders()
-                    .filter(event -> event.is(translator.asNative(sound.name())))
-                    .findFirst();
-
+            final Optional<Holder.Reference<SoundEvent>> reference = BuiltInRegistries.SOUND_EVENT.get(translator.asNative(sound.name()));
             reference.ifPresent(soundEventReference -> target.connection.send(new ClientboundSoundPacket(
                     soundEventReference,
                     SoundSource.valueOf(sound.source().name()),
@@ -277,10 +275,7 @@ public abstract class ImpactorPlatformPlayer extends ImpactorPlatformSource impl
         AdventureTranslator translator = AdventureTranslator.get();
 
         this.asMinecraftPlayer().ifPresent(target -> {
-            final Optional<Holder.Reference<SoundEvent>> reference = BuiltInRegistries.SOUND_EVENT.holders()
-                    .filter(event -> event.is(translator.asNative(sound.name())))
-                    .findFirst();
-
+            final Optional<Holder.Reference<SoundEvent>> reference = BuiltInRegistries.SOUND_EVENT.get(translator.asNative(sound.name()));
             if(reference.isPresent()) {
                 final Entity tracked;
                 if(emitter == Sound.Emitter.self()) {

--- a/minecraft/impl/src/main/java/net/impactdev/impactor/minecraft/plugin/GameImpactorPlugin.java
+++ b/minecraft/impl/src/main/java/net/impactdev/impactor/minecraft/plugin/GameImpactorPlugin.java
@@ -45,7 +45,7 @@ import net.impactdev.impactor.minecraft.scoreboard.ScoreboardModule;
 import net.impactdev.impactor.minecraft.ui.UIModule;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.arguments.EntityArgument;
-import net.minecraft.commands.arguments.ResourceLocationArgument;
+import net.minecraft.commands.arguments.IdentifierArgument;
 import org.incendo.cloud.brigadier.argument.BrigadierMapping;
 import org.incendo.cloud.brigadier.argument.BrigadierMappings;
 import org.incendo.cloud.parser.ArgumentParser;
@@ -76,7 +76,7 @@ public abstract class GameImpactorPlugin extends BaseImpactorPlugin {
         Impactor.instance().events().subscribe(RegisterBrigadierMappingsEvent.class, event -> {
             BrigadierMappings<CommandSource, CommandSourceStack> mappings = (BrigadierMappings<CommandSource, CommandSourceStack>) event.mappings();
             BrigadierMapping<?, CurrencyParser, CommandSourceStack> currency = this.createMapping(
-                    parser -> ResourceLocationArgument.id()
+                    parser -> IdentifierArgument.id()
             );
 
             BrigadierMapping<?, PlatformSourceParser, CommandSourceStack> sources = this.createMapping(

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,6 +1,9 @@
+import org.gradle.kotlin.dsl.mavenCentral
+
 pluginManagement {
     repositories {
         gradlePluginPortal()
+        mavenCentral()
         maven("https://repo.spongepowered.org/repository/maven-public/")
         maven("https://repo.spongepowered.org/repository/maven-releases/")
         maven("https://repo.spongepowered.org/repository/maven-snapshots")


### PR DESCRIPTION
Notes:
~~- net.kyori:event-api:5.0.0-Snapshot is not available anymore. I had to downgrade to 3.0.0~~ Using kyori event-api from jitpack instead
~~- I could not find `net.impactdev.impactor.commands` and `net.impactdev.impactor.api.commands`. Are those modules closed-source, but with source-files in maven? Regardless, I cannot fix errors regarding to those modules not existing.~~ Found it.
~~- Some Gradle errors still exist, which I just cannot make sense of.~~
- You might wanna create a new branch for this mc version and edit the pr to retarget to that new branch

See also:
- https://github.com/NickImpact/ImpactorAPI/pull/5
- https://github.com/NickImpact/Commands/pull/1